### PR TITLE
[feat/WMYH-5] 날짜 선택 위젯 구현

### DIFF
--- a/lib/pages/home/home_page.dart
+++ b/lib/pages/home/home_page.dart
@@ -13,9 +13,11 @@ class HomePage extends StatelessWidget {
       body: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          DateSelector(),
-
-          const SizedBox(height: 16),
+          DateSelector(
+            onDateChanged: (date) {
+              print('선택된 날짜: $date');
+            },
+          ),
 
           Expanded(
             child: ListView.builder(

--- a/lib/pages/home/widgets/date_selector.dart
+++ b/lib/pages/home/widgets/date_selector.dart
@@ -1,66 +1,182 @@
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
 
-class DateSelector extends StatelessWidget {
-  const DateSelector({super.key});
+const double kMonthItemWidth = 60.0;
+const double kDayItemWidth = 60.0;
+const double kPickerHeight = 30.0;
+const int kLeapYear = 2024; // leap year
+
+class DateSelector extends StatefulWidget {
+  final Function(DateTime)? onDateChanged;
+
+  const DateSelector({super.key, this.onDateChanged});
+
+  @override
+  State<DateSelector> createState() => _DateSelectorState();
+}
+
+class _DateSelectorState extends State<DateSelector> {
+  final ScrollController _monthController = ScrollController();
+  final ScrollController _dayController = ScrollController();
+
+  int _selectedMonth = DateTime.now().month;
+  int _selectedDay = DateTime.now().day;
+
+  final List<String> _months = List.generate(
+    12,
+    (index) => DateFormat('MMM').format(DateTime(kLeapYear, index + 1)),
+  );
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _scrollToMonth(_selectedMonth - 1);
+      _scrollToDay(_selectedDay - 1);
+    });
+  }
+
+  void _scrollToMonth(int index) {
+    _monthController.animateTo(
+      index * kMonthItemWidth,
+      duration: const Duration(milliseconds: 300),
+      curve: Curves.easeInOut,
+    );
+  }
+
+  void _scrollToDay(int index) {
+    _dayController.animateTo(
+      index * kDayItemWidth,
+      duration: const Duration(milliseconds: 300),
+      curve: Curves.easeInOut,
+    );
+  }
+
+  void _onMonthTapped(int index) {
+    setState(() {
+      _selectedMonth = index + 1;
+      _adjustDayIfNeeded();
+    });
+    _scrollToMonth(index);
+    _notifyDateChanged();
+  }
+
+  void _onDayTapped(int index) {
+    setState(() {
+      _selectedDay = index + 1;
+    });
+    _scrollToDay(index);
+    _notifyDateChanged();
+  }
+
+  void _adjustDayIfNeeded() {
+    final daysInMonth = DateUtils.getDaysInMonth(kLeapYear, _selectedMonth);
+    if (_selectedDay > daysInMonth) {
+      _selectedDay = daysInMonth;
+    }
+  }
+
+  void _notifyDateChanged() {
+    if (widget.onDateChanged != null) {
+      widget.onDateChanged!(DateTime(kLeapYear, _selectedMonth, _selectedDay));
+    }
+  }
+
+  void _goToToday() {
+    final now = DateTime.now();
+    setState(() {
+      _selectedMonth = now.month;
+      _selectedDay = now.day;
+    });
+    _scrollToMonth(_selectedMonth - 1);
+    _scrollToDay(_selectedDay - 1);
+    _notifyDateChanged();
+  }
 
   @override
   Widget build(BuildContext context) {
-    final today = DateTime.now();
+    final daysInMonth = DateUtils.getDaysInMonth(kLeapYear, _selectedMonth);
+    final days = List.generate(daysInMonth, (index) => (index + 1).toString());
 
-    return SizedBox(
-      height: 100,
-      child: ListView.builder(
-        scrollDirection: Axis.horizontal,
-        itemCount: 7,
-        itemBuilder: (context, index) {
-          final date = today.add(Duration(days: index));
-          final isSelected = index == 3;
-
-          return Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 12),
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.center,
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        _buildHorizontalPicker(
+          type: 'month',
+          controller: _monthController,
+          items: _months,
+          selectedIndex: _selectedMonth - 1,
+          onTap: _onMonthTapped,
+          itemWidth: kMonthItemWidth,
+        ),
+        _buildHorizontalPicker(
+          type: 'day',
+          controller: _dayController,
+          items: days,
+          selectedIndex: _selectedDay - 1,
+          onTap: _onDayTapped,
+          itemWidth: kDayItemWidth,
+        ),
+        Align(
+          alignment: Alignment.centerRight,
+          child: TextButton(
+            onPressed: _goToToday,
+            style: TextButton.styleFrom(
+              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 0),
+            ),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
               children: [
+                Icon(Icons.refresh_rounded, size: 16, color: Colors.grey),
                 Text(
-                  '${date.day}',
-                  style: TextStyle(
-                    fontSize: isSelected ? 34 : 26,
-                    fontWeight: isSelected ? FontWeight.w900 : FontWeight.w700,
-                    leadingDistribution: TextLeadingDistribution.even,
-                    color: isSelected ? Colors.black : Colors.grey,
-                  ),
-                ),
-                Text(
-                  _monthAbbr(date.month),
-                  style: TextStyle(
-                    fontSize: isSelected ? 22 : 14,
-                    fontWeight: isSelected ? FontWeight.w600 : FontWeight.w400,
-                    color: isSelected ? Colors.black : Colors.grey,
-                  ),
+                  ' Today',
+                  style: TextStyle(fontSize: 14, color: Colors.grey),
                 ),
               ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildHorizontalPicker({
+    required String type,
+    required ScrollController controller,
+    required List<String> items,
+    required int selectedIndex,
+    required Function(int) onTap,
+    required double itemWidth,
+  }) {
+    final screenWidth = MediaQuery.of(context).size.width;
+    final horizontalPadding = (screenWidth / 2) - (itemWidth / 2);
+
+    return SizedBox(
+      height: kPickerHeight,
+      child: ListView.builder(
+        controller: controller,
+        scrollDirection: Axis.horizontal,
+        padding: EdgeInsets.symmetric(horizontal: horizontalPadding),
+        itemCount: items.length,
+        itemBuilder: (context, index) {
+          final isSelected = index == selectedIndex;
+          return GestureDetector(
+            onTap: () => onTap(index),
+            child: Container(
+              alignment: Alignment.center,
+              width: itemWidth,
+              child: Text(
+                items[index],
+                style: TextStyle(
+                  fontSize: type == 'month' ? 16 : 20,
+                  fontWeight: isSelected ? FontWeight.bold : FontWeight.normal,
+                  color: isSelected ? Colors.black : Colors.grey,
+                ),
+              ),
             ),
           );
         },
       ),
     );
-  }
-
-  String _monthAbbr(int month) {
-    const months = [
-      'JAN',
-      'FEB',
-      'MAR',
-      'APR',
-      'MAY',
-      'JUN',
-      'JUL',
-      'AUG',
-      'SEP',
-      'OCT',
-      'NOV',
-      'DEC',
-    ];
-    return months[month - 1];
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -152,6 +152,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.5.4"
+  intl:
+    dependency: "direct main"
+    description:
+      name: intl
+      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.20.2"
   leak_tracker:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,6 +34,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
+  intl: ^0.20.2
 
 dev_dependencies:
   flutter_native_splash: ^2.4.5


### PR DESCRIPTION
- intl 패키지 추가
- DateSelector 위젯 구현
- 가로로 스크롤 가능한 월, 일 선택기
- 1년의 모든 날짜를 포함 가능 하도록 윤년인 2024년을 기준으로 표시
- 오늘 날짜로 돌아갈 수 있는 버튼 추가